### PR TITLE
$response object passed as service argument instead of resolveDispositionHeaderFilename() argument

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,14 +11,17 @@
     </parameters>
 
     <services>
-        <service id="igorw_file_serve.response_factory.php" class="%igorw_file_serve.response_factory.php.class%" public="false">
+        <service id="igorw_file_serve.response_factory.php" class="%igorw_file_serve.response_factory.php.class%" public="false" scope="request">
             <argument>%igorw_file_serve.base_dir%</argument>
+            <argument type="service" id="request" />
         </service>
-        <service id="igorw_file_serve.response_factory.sendfile" class="%igorw_file_serve.response_factory.sendfile.class%" public="false">
+        <service id="igorw_file_serve.response_factory.sendfile" class="%igorw_file_serve.response_factory.sendfile.class%" public="false" scope="request">
             <argument>%igorw_file_serve.base_dir%</argument>
+            <argument type="service" id="request" />
         </service>
-        <service id="igorw_file_serve.response_factory.xsendfile" class="%igorw_file_serve.response_factory.xsendfile.class%" public="false">
+        <service id="igorw_file_serve.response_factory.xsendfile" class="%igorw_file_serve.response_factory.xsendfile.class%" public="false" scope="request">
             <argument>%igorw_file_serve.base_dir%</argument>
+            <argument type="service" id="request" />
         </service>
     </services>
 </container>

--- a/Response/AbstractResponseFactory.php
+++ b/Response/AbstractResponseFactory.php
@@ -7,13 +7,15 @@ use Symfony\Component\HttpFoundation\Response;
 abstract class AbstractResponseFactory
 {
     protected $baseDir;
+    protected $request;
     protected $fullFilename;
     protected $contentType;
     protected $options;
 
-    public function __construct($baseDir)
+    public function __construct($baseDir, $request)
     {
         $this->baseDir = $baseDir;
+        $this->request = $request;
     }
 
     public function create($filename, $contentType = 'application/octet-stream', $options = array())
@@ -36,7 +38,6 @@ abstract class AbstractResponseFactory
 
     protected function parseOptions()
     {
-        $this->options['request'] = isset($this->options['request']) ? $this->options['request'] : null;
         $this->options['serve_filename'] = isset($this->options['serve_filename']) ? $this->options['serve_filename'] : basename($this->fullFilename);
         $this->options['inline'] = isset($this->options['inline']) ? (Bool) $this->options['inline'] : true;
     }
@@ -59,17 +60,16 @@ abstract class AbstractResponseFactory
     {
         $disposition = $this->options['inline'] ? 'inline' : 'attachment';
         $filename = $this->options['serve_filename'];
-        $request = $this->options['request'];
 
-        return "$disposition; ".$this->resolveDispositionHeaderFilename($filename, $request);
+        return "$disposition; ".$this->resolveDispositionHeaderFilename($filename);
     }
 
     /**
      * Algorithm inspired by phpBB3
      */
-    protected function resolveDispositionHeaderFilename($filename, $request)
+    protected function resolveDispositionHeaderFilename($filename)
     {
-        $userAgent = !is_null($request) ? $request->headers->get('User-Agent') : null;
+        $userAgent = !is_null($this->request) ? $this->request->headers->get('User-Agent') : null;
 
         if (!$userAgent || preg_match('#MSIE|Safari|Konqueror#', $userAgent)) {
             return "filename=".rawurlencode($filename);

--- a/Response/AbstractResponseFactory.php
+++ b/Response/AbstractResponseFactory.php
@@ -3,6 +3,7 @@
 namespace Igorw\FileServeBundle\Response;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
 
 abstract class AbstractResponseFactory
 {
@@ -12,7 +13,7 @@ abstract class AbstractResponseFactory
     protected $contentType;
     protected $options;
 
-    public function __construct($baseDir, $request)
+    public function __construct($baseDir, Request $request)
     {
         $this->baseDir = $baseDir;
         $this->request = $request;
@@ -69,9 +70,9 @@ abstract class AbstractResponseFactory
      */
     protected function resolveDispositionHeaderFilename($filename)
     {
-        $userAgent = !is_null($this->request) ? $this->request->headers->get('User-Agent') : null;
+        $userAgent = $this->request->headers->get('User-Agent');
 
-        if (!$userAgent || preg_match('#MSIE|Safari|Konqueror#', $userAgent)) {
+        if (preg_match('#MSIE|Safari|Konqueror#', $userAgent)) {
             return "filename=".rawurlencode($filename);
         }
 


### PR DESCRIPTION
$request object is now passed through services.xml instead of passing it optionally in the controller as option.
What do you think?
